### PR TITLE
feat(IN-184): 영상 상세 분석 - 핵심 성과 지표 카드 영역 구현

### DIFF
--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -23,10 +23,6 @@
   /* === section Footer === */
   --footer-logo-width: 180px;
   --footer-logo-height: 59px;
-
-  /* === Dashboard 색상 — TODO: tokens.json에 추가 필요 === */
-  --color-dashboard-positive: #008443;
-  --color-dashboard-negative: #f13d5d;
 }
 
 :root {

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -23,6 +23,10 @@
   /* === section Footer === */
   --footer-logo-width: 180px;
   --footer-logo-height: 59px;
+
+  /* === Dashboard 색상 — TODO: tokens.json에 추가 필요 === */
+  --color-dashboard-positive: #008443;
+  --color-dashboard-negative: #f13d5d;
 }
 
 :root {

--- a/src/entities/video/index.ts
+++ b/src/entities/video/index.ts
@@ -1,1 +1,1 @@
-export type { VideoDetailDto } from './model/types'
+export type { VideoDetailDto, VideoStatsDto, KpiMetric } from './model/types'

--- a/src/entities/video/model/types.ts
+++ b/src/entities/video/model/types.ts
@@ -2,7 +2,26 @@ export interface VideoDetailDto {
   thumbnailUrl: string
   videoUrl: string
   title: string
-  publishedAt: string
+  publishedAt: string // LocalDateTime ISO string (e.g. "2024-08-08T12:00:00")
   description: string | null
   hashtags: string[] | null
+}
+
+export interface KpiMetric {
+  value: number
+  changeRate: number | null // null = 이전 데이터 없음 (최초 수집 등)
+}
+
+export interface VideoStatsDto {
+  collectedAt: string // ISO datetime — 수집 기준 시각
+  viewCount: KpiMetric
+  likeCount: KpiMetric
+  commentCount: KpiMetric
+  shareCount: KpiMetric
+  subscribersGained: KpiMetric
+  ctr: KpiMetric // Double, %
+  engagementRate: KpiMetric // Double, %
+  newViewerRate: KpiMetric // Double, %
+  outlier: KpiMetric // Double, 배수 스코어
+  vph: KpiMetric // Double, Views Per Hour
 }

--- a/src/features/videoDetail/stats/api/videoStatsApi.ts
+++ b/src/features/videoDetail/stats/api/videoStatsApi.ts
@@ -1,0 +1,10 @@
+import type { ApiResponse } from '@/shared/api/types'
+import { axiosInstance } from '@/shared/api'
+import type { VideoStatsDto } from '@/entities/video'
+
+export async function fetchVideoStats(videoId: string): Promise<VideoStatsDto> {
+  const response = await axiosInstance.get<ApiResponse<VideoStatsDto>>(
+    `/videos/${videoId}/stats`
+  )
+  return response.data.responseDto
+}

--- a/src/features/videoDetail/stats/api/videoStatsApi.ts
+++ b/src/features/videoDetail/stats/api/videoStatsApi.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse } from '@/shared/api/types'
+import type { ApiResponse } from '@/shared/api'
 import { axiosInstance } from '@/shared/api'
 import type { VideoStatsDto } from '@/entities/video'
 

--- a/src/features/videoDetail/stats/index.ts
+++ b/src/features/videoDetail/stats/index.ts
@@ -1,0 +1,2 @@
+export { useVideoStats } from './model/useVideoStats'
+export { mockVideoStats } from './mock/mockVideoStats'

--- a/src/features/videoDetail/stats/mock/mockVideoStats.ts
+++ b/src/features/videoDetail/stats/mock/mockVideoStats.ts
@@ -1,0 +1,15 @@
+import type { VideoStatsDto } from '@/entities/video'
+
+export const mockVideoStats: VideoStatsDto = {
+  collectedAt: '2026-01-01T00:00:00',
+  viewCount: { value: 37687938, changeRate: 18.4 },
+  likeCount: { value: 24850394, changeRate: 13.0 },
+  commentCount: { value: 269593, changeRate: 13.0 },
+  shareCount: { value: 83904, changeRate: -13.0 },
+  subscribersGained: { value: 187, changeRate: 13.0 },
+  ctr: { value: 34.0, changeRate: 13.0 },
+  engagementRate: { value: 52.0, changeRate: 13.0 },
+  newViewerRate: { value: 25.0, changeRate: 13.0 },
+  outlier: { value: 1.5, changeRate: 13.0 },
+  vph: { value: 47.0, changeRate: 13.0 },
+}

--- a/src/features/videoDetail/stats/model/useVideoStats.ts
+++ b/src/features/videoDetail/stats/model/useVideoStats.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchVideoStats } from '../api/videoStatsApi'
+
+export function useVideoStats(videoId: string) {
+  return useQuery({
+    queryKey: ['videoStats', videoId],
+    queryFn: () => fetchVideoStats(videoId),
+    enabled: !!videoId,
+  })
+}

--- a/src/pages/videoDetail/ui/VideoDetailPage.tsx
+++ b/src/pages/videoDetail/ui/VideoDetailPage.tsx
@@ -6,6 +6,7 @@ import LeftwardsArrowIcon from '@/shared/assets/leftwards-arrow-bold.svg'
 import { useAuth } from '@/features/auth'
 import { useVideoDetail, mockVideoDetail } from '@/features/videoDetail'
 import { VideoBasicInfo } from '@/widgets/videoDetail/basicInfo'
+import { VideoStatsSection } from '@/widgets/videoDetail/stats'
 
 export function VideoDetailPage() {
   const router = useRouter()
@@ -34,6 +35,7 @@ export function VideoDetailPage() {
       </div>
     )
   }
+  if (isInitializing) return null
 
   return (
     <div className='flex w-full flex-col gap-24 bg-background-gray-default px-24 pt-24 pb-96'>
@@ -52,7 +54,8 @@ export function VideoDetailPage() {
         {/* 영상 기본 정보 */}
         <VideoBasicInfo video={video} />
 
-        {/* TODO: 티켓 2 — 핵심 지표 카드 영역 */}
+        {/* 핵심 성과 지표 카드 */}
+        <VideoStatsSection videoId={videoId} />
 
         {/* TODO: 티켓 3 — 시청 지속률 그래프 영역 */}
       </div>

--- a/src/shared/api/msw/handlers/index.ts
+++ b/src/shared/api/msw/handlers/index.ts
@@ -5,6 +5,7 @@ import { trendMagazineHandlers } from './trendMagazineHandlers'
 import { trendingVideosHandlers } from './trendingVideosHandlers'
 import { videoDetailHandlers } from './videoDetailHandlers'
 import { channelKpiHandlers } from './channelKpiHandlers'
+import { videoStatsHandlers } from './videoStatsHandlers'
 
 export const handlers = [
   ...authHandlers,
@@ -14,4 +15,5 @@ export const handlers = [
   ...onboardingHandlers,
   ...videoDetailHandlers,
   ...channelKpiHandlers,
+  ...videoStatsHandlers,
 ]

--- a/src/shared/api/msw/handlers/videoStatsHandlers.ts
+++ b/src/shared/api/msw/handlers/videoStatsHandlers.ts
@@ -1,0 +1,15 @@
+import { http, HttpResponse } from 'msw'
+import { mockVideoStats } from '@/features/videoDetail/stats'
+
+export const videoStatsHandlers = [
+  http.get(
+    `${process.env.NEXT_PUBLIC_API_URL}/videos/:videoId/stats`,
+    async () => {
+      return HttpResponse.json({
+        success: true,
+        responseDto: mockVideoStats,
+        error: null,
+      })
+    }
+  ),
+]

--- a/src/shared/lib/format.ts
+++ b/src/shared/lib/format.ts
@@ -6,6 +6,17 @@ export function formatComma(count: number | null | undefined): string {
   return count.toLocaleString('ko-KR')
 }
 
+// 만 단위 포맷팅 37,687,938 => 3768만 7938 / 83,904 => 8만 3904 / 187 => 187
+export function formatKoreanUnit(value: number): string {
+  const floor = Math.floor(value)
+  if (floor >= 10000) {
+    const man = Math.floor(floor / 10000)
+    const remainder = floor % 10000
+    return remainder > 0 ? `${man}만 ${remainder}` : `${man}만`
+  }
+  return String(floor)
+}
+
 // 1000명 단위 포맷팅 3,700 => 3천
 export function formatThousands(count: number): string {
   if (count >= 1000) {

--- a/src/widgets/videoDetail/stats/index.ts
+++ b/src/widgets/videoDetail/stats/index.ts
@@ -1,0 +1,1 @@
+export { VideoStatsSection } from './ui/VideoStatsSection'

--- a/src/widgets/videoDetail/stats/ui/VideoStatsCard.tsx
+++ b/src/widgets/videoDetail/stats/ui/VideoStatsCard.tsx
@@ -1,0 +1,107 @@
+import { type ReactNode } from 'react'
+import { cn } from '@/shared/lib/utils'
+import { formatKoreanUnit } from '@/shared/lib/format'
+import type { KpiMetric } from '@/entities/video'
+import InfoIcon from '@/shared/assets/info-bold.svg'
+
+type ValueFormat = 'korean' | 'percent' | 'float'
+
+interface VideoStatsCardProps {
+  icon: ReactNode
+  label: string
+  description?: string
+  hasTooltip?: boolean
+  metric: KpiMetric
+  valueFormat: ValueFormat
+}
+
+function formatValue(value: number, format: ValueFormat): string {
+  switch (format) {
+    case 'korean':
+      return formatKoreanUnit(value)
+    case 'percent': {
+      const n = Number.isInteger(value) ? value : parseFloat(value.toFixed(1))
+      return `${n}%`
+    }
+    case 'float':
+      return Number.isInteger(value) ? String(value) : value.toFixed(1)
+  }
+}
+
+function ChangeRateBadge({ changeRate }: { changeRate: number | null }) {
+  if (changeRate === null) {
+    return (
+      <span className='text-noto-title-sm-bold text-text-and-icon-secondary'>
+        —
+      </span>
+    )
+  }
+
+  const isPositive = changeRate >= 0
+  const sign = isPositive ? '+' : ''
+  const formatted = Number.isInteger(changeRate)
+    ? changeRate
+    : parseFloat(changeRate.toFixed(1))
+
+  return (
+    <span
+      className={cn(
+        'text-noto-title-sm-bold',
+        isPositive
+          ? 'text-[var(--color-dashboard-positive)]'
+          : 'text-[var(--color-dashboard-negative)]'
+      )}>
+      {`${sign}${formatted}%`}
+    </span>
+  )
+}
+
+export function VideoStatsCard({
+  icon,
+  label,
+  description,
+  hasTooltip = false,
+  metric,
+  valueFormat,
+}: VideoStatsCardProps) {
+  return (
+    <div className='flex w-full flex-1 items-center gap-24 rounded-12 bg-white p-32 shadow-[0px_2px_6px_0px_rgba(13,13,13,0.04)] sm:min-w-[374px] sm:max-w-[558px]'>
+      {/* 왼쪽: 아이콘 + 레이블 */}
+      <div className='flex min-w-0 flex-1 items-center gap-16'>
+        <div className='flex shrink-0 items-center rounded-[15px] bg-[#fcf8ff] p-5'>
+          <div className='flex size-[30px] items-center justify-center'>
+            {icon}
+          </div>
+        </div>
+        <div className='flex min-w-0 flex-1 flex-col gap-4'>
+          <p className='text-noto-title-sm-normal text-text-and-icon-primary'>
+            {label}
+          </p>
+          {description && (
+            <div className='flex items-center gap-4'>
+              <p className='whitespace-nowrap text-noto-caption-md-normal text-text-and-icon-secondary'>
+                {description}
+              </p>
+              {hasTooltip && (
+                <InfoIcon className='size-12 shrink-0 text-text-and-icon-secondary' />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 오른쪽: 값 + 채널 평균 비교 */}
+      <div className='flex min-w-0 flex-1 flex-col items-end gap-2'>
+        <p className='w-full text-right text-ibm-heading-sm-normal text-text-and-icon-primary'>
+          {formatValue(metric.value, valueFormat)}
+        </p>
+        <div className='flex w-full items-center justify-end gap-6 whitespace-nowrap'>
+          <span className='text-noto-caption-md-normal text-text-and-icon-secondary'>
+            채널 평균보다
+          </span>
+          <ChangeRateBadge changeRate={metric.changeRate} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/widgets/videoDetail/stats/ui/VideoStatsSection.tsx
+++ b/src/widgets/videoDetail/stats/ui/VideoStatsSection.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { VideoStatsCard } from './VideoStatsCard'
+import { useVideoStats, mockVideoStats } from '@/features/videoDetail/stats'
+import { formatDate } from '@/shared/lib/format'
+import type { VideoStatsDto } from '@/entities/video'
+
+import EyeIcon from '@/shared/assets/eye-bold.svg'
+import LikeIcon from '@/shared/assets/like-bold.svg'
+import CommentIcon from '@/shared/assets/comment-bold.svg'
+import ShareIcon from '@/shared/assets/share-bold.svg'
+import ClickIcon from '@/shared/assets/click-bold.svg'
+import UsersIcon from '@/shared/assets/users-bold.svg'
+import SubscribeIcon from '@/shared/assets/subscribe-bold.svg'
+import ParticipationIcon from '@/shared/assets/participation-bold.svg'
+import VphIcon from '@/shared/assets/vph-bold.svg'
+import OutlierIcon from '@/shared/assets/outlier-bold.svg'
+
+const ICON_CLASS = 'size-20 text-text-and-icon-default'
+
+function buildGroups(data: VideoStatsDto) {
+  const { year, month, day } = formatDate(data.collectedAt)
+  const collectedLabel = `${year}년 ${Number(month)}월 ${Number(day)}일 기준`
+
+  return [
+    {
+      title: '기본 지표',
+      cards: [
+        {
+          icon: <EyeIcon className={ICON_CLASS} />,
+          label: '총 조회수',
+          description: collectedLabel,
+          metric: data.viewCount,
+          valueFormat: 'korean' as const,
+        },
+        {
+          icon: <LikeIcon className={ICON_CLASS} />,
+          label: '좋아요 수',
+          metric: data.likeCount,
+          valueFormat: 'korean' as const,
+        },
+        {
+          icon: <CommentIcon className={ICON_CLASS} />,
+          label: '댓글 수',
+          metric: data.commentCount,
+          valueFormat: 'korean' as const,
+        },
+        {
+          icon: <ShareIcon className={ICON_CLASS} />,
+          label: '공유 수',
+          metric: data.shareCount,
+          valueFormat: 'korean' as const,
+        },
+      ],
+    },
+    {
+      title: '유입 지표',
+      cards: [
+        {
+          icon: <ClickIcon className={ICON_CLASS} />,
+          label: 'CTR',
+          description: '썸네일 클릭률',
+          hasTooltip: true,
+          metric: data.ctr,
+          valueFormat: 'percent' as const,
+        },
+        {
+          icon: <UsersIcon className={ICON_CLASS} />,
+          label: '신규 유입 비율',
+          description: '구독자가 아닌 신규 시청자 비율',
+          hasTooltip: true,
+          metric: data.newViewerRate,
+          valueFormat: 'percent' as const,
+        },
+        {
+          icon: <SubscribeIcon className={ICON_CLASS} />,
+          label: '구독 전환 수',
+          description: '영상 시청 후 구독으로 이어진 수',
+          hasTooltip: true,
+          metric: data.subscribersGained,
+          valueFormat: 'korean' as const,
+        },
+      ],
+    },
+    {
+      title: '참여 지표',
+      cards: [
+        {
+          icon: <ParticipationIcon className={ICON_CLASS} />,
+          label: '영상 참여율',
+          description: '개별 영상 참여율',
+          hasTooltip: true,
+          metric: data.engagementRate,
+          valueFormat: 'percent' as const,
+        },
+      ],
+    },
+    {
+      title: '성장 지표',
+      cards: [
+        {
+          icon: <VphIcon className={ICON_CLASS} />,
+          label: 'VPH',
+          description: '시간 당 조회수',
+          hasTooltip: true,
+          metric: data.vph,
+          valueFormat: 'float' as const,
+        },
+        {
+          icon: <OutlierIcon className={ICON_CLASS} />,
+          label: 'Outlier',
+          description: '채널 평균 조회수 대비 상승배수',
+          hasTooltip: true,
+          metric: data.outlier,
+          valueFormat: 'float' as const,
+        },
+      ],
+    },
+  ]
+}
+
+interface VideoStatsSectionProps {
+  videoId: string
+}
+
+export function VideoStatsSection({ videoId }: VideoStatsSectionProps) {
+  const { data: apiData, isLoading } = useVideoStats(videoId)
+  const stats = apiData ?? mockVideoStats
+
+  if (isLoading) return null
+
+  const groups = buildGroups(stats)
+
+  return (
+    <section className='flex flex-col gap-32'>
+      {groups.map((group) => (
+        <div key={group.title} className='flex flex-col gap-16'>
+          <div className='flex w-full items-center justify-center px-[2px]'>
+            <p className='min-w-px flex-1 text-ibm-title-md-normal text-text-and-icon-default'>
+              {group.title}
+            </p>
+          </div>
+          <div className='flex flex-wrap items-start gap-16'>
+            {group.cards.map((card) => (
+              <VideoStatsCard key={card.label} {...card} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  )
+}


### PR DESCRIPTION
## 📌 작업 개요
feat(IN-184): 영상 상세 분석 - 핵심 성과 지표 카드 영역 구현

## 🗂 작업 유형

> 해당하는 항목에 `x`를 채워 주세요.

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일 / UI 수정 (style)
- [ ] 성능 개선 (perf)
- [ ] 테스트 (test)
- [ ] 기타 (chore, docs 등)

## ✏️ 작업 내용
  1. **핵심 성과 지표 카드 영역 구현** (`GET /api/v1/videos/{videoId}/stats`)
     - 기본 지표: 총 조회수, 좋아요 수, 댓글 수, 공유 수
     - 유입 지표: CTR, 신규 유입 비율, 구독 전환 수
     - 참여 지표: 영상 참여율
     - 성장 지표: VPH, Outlier

  2. **FSD 구조 적용**
     - `entities/video` — `VideoDetailDto`, `KpiMetric`, `VideoStatsDto` 타입 정의
     - `features/videoDetail/stats` — API, TanStack Query 훅, 목 데이터
     - `widgets/videoDetail/stats` — `VideoStatsCard`, `VideoStatsSection`

  3. **영상 상세 페이지 라우팅** (`/[id]/video/[videoId]`)
     - `app/[id]/video/[videoId]/page.ts` 라우트 추가
     - `VideoDetailPage` 구현 (인증 가드 포함)

  4. **기타**
     - `shared/lib/format.ts` — `formatKoreanUnit` 추가 (한국식 만 단위 포맷)
     - `shared/api/index.ts` — `ApiResponse` 타입 export 추가
     - MSW 핸들러 추가

## ✅ 셀프 체크리스트

> 머지 전 직접 확인해 주세요.

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 콘솔 로그, 주석, 디버그 코드 제거
- [x] 타입 에러 없음

## 💬 리뷰어에게

>
