### PR TITLE
feat(IN-312): 마이페이지 알림설정 api 연동

### DIFF
--- a/src/features/me/alarm/api/alarmApi.ts
+++ b/src/features/me/alarm/api/alarmApi.ts
@@ -1,12 +1,12 @@
 import type { ApiResponse } from '@/shared/api/types'
 import { axiosInstance } from '@/shared/api'
-import type { alarms, alarmsDto } from '../model/types'
+import type { Alarms, AlarmsDto } from '../model/types'
 
-export async function fetchAlarm(): Promise<alarmsDto> {
+export async function fetchAlarm(): Promise<AlarmsDto> {
   const response =
-    await axiosInstance.get<ApiResponse<alarmsDto>>(`/user/alarms`)
+    await axiosInstance.get<ApiResponse<AlarmsDto>>(`/user/alarms`)
   return response.data.responseDto
 }
 
-export const postAlarm = (body: alarms) =>
+export const postAlarm = (body: Alarms) =>
   axiosInstance.put('/user/alarms', body)

--- a/src/features/me/alarm/api/alarmApi.ts
+++ b/src/features/me/alarm/api/alarmApi.ts
@@ -1,0 +1,12 @@
+import type { ApiResponse } from '@/shared/api/types'
+import { axiosInstance } from '@/shared/api'
+import type { alarms, alarmsDto } from '../model/types'
+
+export async function fetchAlarm(): Promise<alarmsDto> {
+  const response =
+    await axiosInstance.get<ApiResponse<alarmsDto>>(`/user/alarms`)
+  return response.data.responseDto
+}
+
+export const postAlarm = (body: alarms) =>
+  axiosInstance.put('/user/alarms', body)

--- a/src/features/me/alarm/index.ts
+++ b/src/features/me/alarm/index.ts
@@ -1,0 +1,1 @@
+export { mockAlarm } from './mock/mockAlarm'

--- a/src/features/me/alarm/mock/mockAlarm.ts
+++ b/src/features/me/alarm/mock/mockAlarm.ts
@@ -1,6 +1,6 @@
-import type { alarmsDto } from '../model/types'
+import type { AlarmsDto } from '../model/types'
 
-export const mockAlarm: alarmsDto = {
+export const mockAlarm: AlarmsDto = {
   alarmEmail: 'hong@gmail.com',
   alarms: [
     {

--- a/src/features/me/alarm/mock/mockAlarm.ts
+++ b/src/features/me/alarm/mock/mockAlarm.ts
@@ -1,0 +1,19 @@
+import type { alarmsDto } from '../model/types'
+
+export const mockAlarm: alarmsDto = {
+  alarmEmail: 'hong@gmail.com',
+  alarms: [
+    {
+      alarmType: 'PAYMENT',
+      enabled: false,
+    },
+    {
+      alarmType: 'FEATURE_UPDATE',
+      enabled: true,
+    },
+    {
+      alarmType: 'EVENT_BENEFIT',
+      enabled: false,
+    },
+  ],
+}

--- a/src/features/me/alarm/model/types.ts
+++ b/src/features/me/alarm/model/types.ts
@@ -1,0 +1,11 @@
+export type AlarmType = 'PAYMENT' | 'FEATURE_UPDATE' | 'EVENT_BENEFIT'
+
+export interface alarms {
+  alarmType: AlarmType
+  enabled: boolean
+}
+
+export interface alarmsDto {
+  alarmEmail: string
+  alarms: alarms[]
+}

--- a/src/features/me/alarm/model/types.ts
+++ b/src/features/me/alarm/model/types.ts
@@ -1,11 +1,11 @@
 export type AlarmType = 'PAYMENT' | 'FEATURE_UPDATE' | 'EVENT_BENEFIT'
 
-export interface alarms {
+export interface Alarms {
   alarmType: AlarmType
   enabled: boolean
 }
 
-export interface alarmsDto {
+export interface AlarmsDto {
   alarmEmail: string
-  alarms: alarms[]
+  alarms: Alarms[]
 }

--- a/src/features/me/alarm/model/useAlarm.ts
+++ b/src/features/me/alarm/model/useAlarm.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchAlarm, postAlarm } from '../api/alarmApi'
-import type { alarms } from '../model/types'
+import type { Alarms } from '../model/types'
 import { useAuthStore } from '@/shared/api'
 
 export function useAlarm() {
@@ -15,7 +15,7 @@ export function useAlarm() {
 export function useEditAlarm() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (body: alarms) => postAlarm(body),
+    mutationFn: (body: Alarms) => postAlarm(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['alarm'] })
     },

--- a/src/features/me/alarm/model/useAlarm.ts
+++ b/src/features/me/alarm/model/useAlarm.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchAlarm, postAlarm } from '../api/alarmApi'
+import type { alarms } from '../model/types'
+import { useAuthStore } from '@/shared/api'
+
+export function useAlarm() {
+  const accessToken = useAuthStore((state) => state.accessToken)
+  return useQuery({
+    queryKey: ['alarm'],
+    queryFn: () => fetchAlarm(),
+    enabled: !!accessToken,
+  })
+}
+
+export function useEditAlarm() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: alarms) => postAlarm(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['alarm'] })
+    },
+  })
+}

--- a/src/pages/me/alarm/ui/MyAlarmPage.tsx
+++ b/src/pages/me/alarm/ui/MyAlarmPage.tsx
@@ -1,8 +1,19 @@
 'use client'
 
 import { Switch } from '@/shared/ui/shadcn/Switch'
+import { useAlarm, useEditAlarm } from '@/features/me/alarm/model/useAlarm'
+import type { AlarmType } from '@/features/me/alarm/model/types'
 
 export function MyAlarmPage() {
+  const { data } = useAlarm()
+  const { mutate } = useEditAlarm()
+
+  const getEnabled = (type: AlarmType) =>
+    data?.alarms.find((a) => a.alarmType === type)?.enabled ?? false
+
+  const handleToggle = (type: AlarmType) =>
+    mutate({ alarmType: type, enabled: !getEnabled(type) })
+
   return (
     <div className='flex h-fit w-full flex-col gap-xl p-md'>
       {/* 타이틀 */}
@@ -23,7 +34,6 @@ export function MyAlarmPage() {
                 결제 관련 중요한 알림
               </span>
             </div>
-            <Switch aria-label='결제 알림 수신' />
           </div>
 
           <div className='flex items-end justify-between gap-8'>
@@ -35,7 +45,11 @@ export function MyAlarmPage() {
                 결제 완료, 실패, 다음 결제 예정일을 알려드려요
               </span>
             </div>
-            <Switch aria-label='결제 관련 알림 수신' />
+            <Switch
+              aria-label='결제 관련 알림 수신'
+              checked={getEnabled('PAYMENT')}
+              onCheckedChange={() => handleToggle('PAYMENT')}
+            />
           </div>
         </div>
         {/* 마케팅 알림 */}
@@ -49,7 +63,6 @@ export function MyAlarmPage() {
                 새 기능 및 이벤트 안내 (선택)
               </span>
             </div>
-            <Switch aria-label='마케팅 알림 수신' />
           </div>
 
           <div className='flex items-end justify-between gap-8'>
@@ -61,7 +74,11 @@ export function MyAlarmPage() {
                 플랫폼의 새로운 기능을 가장 먼저 알려드려요
               </span>
             </div>
-            <Switch aria-label='새 기능 안내 수신' />
+            <Switch
+              aria-label='새 기능 안내 수신'
+              checked={getEnabled('FEATURE_UPDATE')}
+              onCheckedChange={() => handleToggle('FEATURE_UPDATE')}
+            />
           </div>
 
           <div className='flex items-end justify-between gap-8'>
@@ -73,7 +90,11 @@ export function MyAlarmPage() {
                 특별 할인이나 이벤트 정보를 보내드려요
               </span>
             </div>
-            <Switch aria-label='이벤트 및 혜택 수신' />
+            <Switch
+              aria-label='이벤트 및 혜택 수신'
+              checked={getEnabled('EVENT_BENEFIT')}
+              onCheckedChange={() => handleToggle('EVENT_BENEFIT')}
+            />
           </div>
         </div>
       </div>

--- a/src/shared/api/msw/handlers/index.ts
+++ b/src/shared/api/msw/handlers/index.ts
@@ -22,6 +22,7 @@ import { influencerSummaryHandlers } from './influencerSummaryHandlers'
 import { influencerBrandHandlers } from './influencerBrandHandlers'
 import { brandAnalysisHandlers } from './brandAnalysisHandlers'
 import { myProfileHandlers } from './myProfileHandlers'
+import { myAlarmHandlers } from './myAlarmHandlers'
 
 export const handlers = [
   ...authHandlers,
@@ -48,4 +49,5 @@ export const handlers = [
   ...influencerBrandHandlers,
   ...brandAnalysisHandlers,
   ...myProfileHandlers,
+  ...myAlarmHandlers,
 ]

--- a/src/shared/api/msw/handlers/myAlarmHandlers.ts
+++ b/src/shared/api/msw/handlers/myAlarmHandlers.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+import { mockAlarm } from '@/features/me/alarm'
+import type { AlarmType } from '@/features/me/alarm/model/types'
+
+export const myAlarmHandlers = [
+  http.get(`${process.env.NEXT_PUBLIC_API_URL}/user/alarms`, () => {
+    return HttpResponse.json({
+      success: true,
+      responseDto: mockAlarm,
+      error: null,
+    })
+  }),
+  http.put(
+    `${process.env.NEXT_PUBLIC_API_URL}/user/alarms`,
+    async ({ request }) => {
+      const body = (await request.json()) as {
+        alarmType: AlarmType
+        enabled: boolean
+      }
+      const alarm = mockAlarm.alarms.find((a) => a.alarmType === body.alarmType)
+      if (alarm) alarm.enabled = body.enabled
+      return HttpResponse.json({
+        isSuccess: true,
+        responseDto: body,
+        error: null,
+      })
+    },
+  ),
+]

--- a/src/shared/api/msw/handlers/myAlarmHandlers.ts
+++ b/src/shared/api/msw/handlers/myAlarmHandlers.ts
@@ -24,6 +24,6 @@ export const myAlarmHandlers = [
         responseDto: body,
         error: null,
       })
-    },
+    }
   ),
 ]


### PR DESCRIPTION
## 📌 작업 개요

> feat(IN-312): 마이페이지 알림설정 api 연동

## 🗂 작업 유형

> 해당하는 항목에 `x`를 채워 주세요.

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일 / UI 수정 (style)
- [ ] 성능 개선 (perf)
- [ ] 테스트 (test)
- [ ] 기타 (chore, docs 등)

## ✏️ 작업 내용

## ✅ 셀프 체크리스트

> 머지 전 직접 확인해 주세요.

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 콘솔 로그, 주석, 디버그 코드 제거
- [x] 타입 에러 없음

## 💬 리뷰어에게

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 설정 관리 기능 추가
  * 결제, 새 기능 업데이트, 이벤트 혜택 등 세 가지 유형의 알림을 개별적으로 활성화/비활성화할 수 있도록 개선
  * 알림 설정이 실시간으로 서버와 동기화되는 제어형 UI로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->