### PR TITLE
refactor: API 응답에 대한 mock 폴백(?? mock) 제거

### DIFF
--- a/src/pages/videoDetail/ui/VideoDetailPage.tsx
+++ b/src/pages/videoDetail/ui/VideoDetailPage.tsx
@@ -4,7 +4,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import LeftwardsArrowIcon from '@/shared/assets/leftwards-arrow-bold.svg'
 import { useAuth } from '@/features/auth'
-import { useVideoDetail, mockVideoDetail } from '@/features/videoDetail'
+import { useVideoDetail } from '@/features/videoDetail'
 import { VideoBasicInfo } from '@/widgets/videoDetail/basicInfo'
 import { VideoStatsSection } from '@/widgets/videoDetail/stats'
 import { RetentionSection } from '@/widgets/videoDetail/retention'
@@ -22,8 +22,7 @@ export function VideoDetailPage() {
   const params = useParams<{ videoId: string }>()
   const videoId = params!.videoId
 
-  const { data: apiData, isLoading, isError } = useVideoDetail(videoId)
-  const video = apiData ?? mockVideoDetail
+  const { data: video, isLoading, isError } = useVideoDetail(videoId)
 
   if (isLoading) return null
 
@@ -37,6 +36,7 @@ export function VideoDetailPage() {
     )
   }
   if (isInitializing) return null
+  if (!video) return null
 
   return (
     <div className='flex w-full flex-col gap-24 bg-background-gray-default px-24 pt-24 pb-96'>

--- a/src/widgets/channel/Kpi/ui/KpiSection.tsx
+++ b/src/widgets/channel/Kpi/ui/KpiSection.tsx
@@ -1,4 +1,4 @@
-import { KpiCard, mockKpi } from '@/entities/channel/kpiCard'
+import { KpiCard } from '@/entities/channel/kpiCard'
 import IconEye from '@/shared/assets/eye-bold.svg'
 import IconParticipation from '@/shared/assets/participation-bold.svg'
 import IconClock from '@/shared/assets/clock-bold.svg'
@@ -7,10 +7,9 @@ import { useKpi } from '@/features/channel/kpi'
 import { Skeleton } from '@/shared/ui/shadcn/skeleton'
 
 export function KpiSection({ channelId }: { channelId: string }) {
-  const { data: apiData, isFetching, isError } = useKpi(channelId)
-  const data = apiData ?? mockKpi
+  const { data, isFetching, isError } = useKpi(channelId)
 
-  if (isFetching || isError) {
+  if (isFetching || isError || !data) {
     return (
       //스켈레톤 UI, 로딩중일 때 상태를 표시합니다.
       <section className='flex h-fit w-full gap-24'>

--- a/src/widgets/influencerDetail/channelSummary/ui/ChannelSummarySection.tsx
+++ b/src/widgets/influencerDetail/channelSummary/ui/ChannelSummarySection.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { mockInfluencerSummary } from '@/entities/influencerDetail'
 import { useInfluencerSummary } from '@/features/influencerDetail'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/shared/ui/button'
@@ -9,8 +8,7 @@ import IconArticle from '@/shared/assets/article-bold.svg'
 import IconRefresh from '@/shared/assets/refresh-bold.svg'
 
 export function ChannelSummarySection({ channelId }: { channelId: string }) {
-  const { data: apiData, isLoading, isError } = useInfluencerSummary(channelId)
-  const data = apiData ?? mockInfluencerSummary
+  const { data, isLoading, isError } = useInfluencerSummary(channelId)
 
   const queryClient = useQueryClient()
 
@@ -65,6 +63,8 @@ export function ChannelSummarySection({ channelId }: { channelId: string }) {
       </div>
     )
   }
+
+  if (!data) return null
 
   return (
     <div className='flex flex-col gap-32 rounded-12 bg-white p-24 pb-32'>

--- a/src/widgets/influencerDetail/engagementAnalytics/ui/EngagementAnalyticsSection.tsx
+++ b/src/widgets/influencerDetail/engagementAnalytics/ui/EngagementAnalyticsSection.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import axios from 'axios'
-import { mockInfluencerDetail } from '@/entities/influencerDetail'
 import {
   ContentChart,
   FormatBarChart,
@@ -28,8 +27,6 @@ export function EngagementAnalyticsSection({
     isError &&
     axios.isAxiosError(error) &&
     error.response?.data?.error?.code === 'CHANNEL_INSIGHT_400'
-
-  const data = apiData ?? mockInfluencerDetail
 
   if (isFetching || (isError && !insightErrorCode)) {
     return (
@@ -74,6 +71,9 @@ export function EngagementAnalyticsSection({
       </div>
     )
   }
+
+  if (!apiData) return null
+  const data = apiData
 
   return (
     <div className='flex flex-col gap-32 rounded-12 bg-white p-24 pb-32 shadow-[0_2px_6px_0_rgba(13,13,13,0.04)]'>

--- a/src/widgets/influencerDetail/impactMetrics/ui/ImpactMetricsSection.tsx
+++ b/src/widgets/influencerDetail/impactMetrics/ui/ImpactMetricsSection.tsx
@@ -7,10 +7,7 @@ import {
   ImpactMetricsList,
   getImpactTier,
 } from '@/entities/influencerDetail/impactMetrics'
-import {
-  mockInfluencerDetail,
-  FrequencyTrend,
-} from '@/entities/influencerDetail'
+import { FrequencyTrend } from '@/entities/influencerDetail'
 import { useInfluencerDetail } from '@/features/influencerDetail'
 import IconChart from '@/shared/assets/chart-bold.svg'
 import IconDown from '@/shared/assets/down-bold.svg'
@@ -39,9 +36,6 @@ export function ImpactMetricsSection({ channelId }: { channelId: string }) {
     isError &&
     axios.isAxiosError(error) &&
     error.response?.data?.error?.code === 'CHANNEL_INSIGHT_400'
-
-  const data = apiData ?? mockInfluencerDetail
-  const { audience, content, activity, advertisement } = data
 
   if (isFetching || (isError && !insightErrorCode)) {
     return (
@@ -114,6 +108,9 @@ export function ImpactMetricsSection({ channelId }: { channelId: string }) {
       </div>
     )
   }
+
+  if (!apiData) return null
+  const { audience, content, activity, advertisement } = apiData
 
   return (
     <div className='flex flex-col gap-32 rounded-12 bg-white p-24 pb-32'>

--- a/src/widgets/influencerDetail/influencerBaseInfo/ui/InfluencerBaseInfo.tsx
+++ b/src/widgets/influencerDetail/influencerBaseInfo/ui/InfluencerBaseInfo.tsx
@@ -3,7 +3,6 @@ import Image from 'next/image'
 
 import { useInfluencerDetail } from '@/features/influencerDetail'
 import { useBookmarkToggle } from '@/features/influencer'
-import { mockInfluencerDetail } from '@/entities/influencerDetail'
 import { buttonVariants } from '@/shared/ui/button'
 import { Skeleton } from '@/shared/ui/shadcn/skeleton'
 import { format10Thousands } from '@/shared/lib/format'
@@ -13,12 +12,10 @@ import { HashtagBox } from '@/shared/ui'
 import { HeartButton } from '@/shared/ui/heart-button'
 
 export function InfluencerBaseInfo({ channelId }: { channelId: string }) {
-  const { data: apiData, isFetching, isError } = useInfluencerDetail(channelId)
+  const { data, isFetching, isError } = useInfluencerDetail(channelId)
   const toggleBookmark = useBookmarkToggle()
 
-  const data = apiData ?? mockInfluencerDetail
-
-  if (isFetching || isError) {
+  if (isFetching || isError || !data) {
     return (
       <div className='h-fit w-full overflow-hidden rounded-10 bg-white shadow-[0_2px_6px_0_rgba(13,13,13,0.04)]'>
         <Skeleton className='relative h-[25.2rem] w-full' />

--- a/src/widgets/main/channelProfile/ui/ChannelProfileSection.tsx
+++ b/src/widgets/main/channelProfile/ui/ChannelProfileSection.tsx
@@ -14,10 +14,7 @@ import {
   formatThousands,
   formatDate,
 } from '@/shared/lib/format'
-import {
-  useChannelProfile,
-  mockChannelProfile,
-} from '@/features/main/channelProfile'
+import { useChannelProfile } from '@/features/main/channelProfile'
 import RedirectIcon from '@/shared/assets/redirect-bold.svg'
 
 type ChannelProfileSectionVariant = 'default' | 'dashboard'
@@ -36,10 +33,9 @@ export function ChannelProfileSection({
   variant = 'default',
 }: ChannelProfileSectionProps) {
   const queryClient = useQueryClient()
-  const { data: apiData, isLoading } = useChannelProfile()
-  const data = apiData ?? mockChannelProfile
+  const { data, isLoading } = useChannelProfile()
 
-  if (isLoading) {
+  if (isLoading || !data) {
     return (
       //스켈레톤 UI, 로딩중일 때 상태를 표시합니다.
       <section className='flex h-fit w-full flex-col gap-[10rem] p-(--semantic-breakpoint-spacing-3xl) md:flex-row'>

--- a/src/widgets/videoDetail/retention/ui/RetentionSection.tsx
+++ b/src/widgets/videoDetail/retention/ui/RetentionSection.tsx
@@ -5,9 +5,6 @@ import {
   useRetention,
   useRetentionSummary,
   useRetentionDropPoints,
-  mockRetentionData,
-  mockRetentionSummary,
-  mockDropPoints,
 } from '@/features/videoDetail/retention'
 import type { DropPoint } from '@/features/videoDetail/retention'
 import { RetentionChart, formatDuration } from './RetentionChart'
@@ -112,12 +109,12 @@ export function RetentionSection({ videoId }: RetentionSectionProps) {
   const { data: dropPointsData, isLoading: dropLoading } =
     useRetentionDropPoints(videoId)
 
-  const retention = retentionData?.retentionData ?? mockRetentionData
-  const summary = summaryData?.retentionData ?? mockRetentionSummary
-  const dropPoints = dropPointsData?.dropPoints ?? mockDropPoints
+  const retention = retentionData?.retentionData ?? []
+  const summary = summaryData?.retentionData
+  const dropPoints = dropPointsData?.dropPoints ?? []
 
   const isLoading = retentionLoading || summaryLoading || dropLoading
-  const isPositive = summary.relativeRetentionAvg >= 1
+  const isPositive = (summary?.relativeRetentionAvg ?? 0) >= 1
 
   return (
     <section className='flex flex-col gap-16'>
@@ -145,7 +142,7 @@ export function RetentionSection({ videoId }: RetentionSectionProps) {
           ) : (
             <div className='flex flex-col gap-2 px-40'>
               <p className='text-ibm-title-lg-normal text-text-and-icon-default'>
-                {formatDuration(summary.avgWatchDuration)}
+                {formatDuration(summary?.avgWatchDuration ?? 0)}
               </p>
               <div className='flex items-center gap-6'>
                 <p className='text-noto-caption-md-normal text-text-and-icon-secondary'>
@@ -155,7 +152,7 @@ export function RetentionSection({ videoId }: RetentionSectionProps) {
                   className={`text-noto-title-sm-bold ${
                     isPositive ? 'text-feedback-success' : 'text-feedback-error'
                   }`}>
-                  {formatRelativeAvg(summary.relativeRetentionAvg)}
+                  {formatRelativeAvg(summary?.relativeRetentionAvg ?? 0)}
                 </p>
               </div>
             </div>
@@ -181,7 +178,7 @@ export function RetentionSection({ videoId }: RetentionSectionProps) {
             <div className='px-24'>
               <RetentionChart
                 data={retention}
-                avgWatchDuration={summary.avgWatchDuration}
+                avgWatchDuration={summary?.avgWatchDuration ?? 0}
                 hoveredSection={hoveredSection}
                 onSectionHover={setHoveredSection}
               />

--- a/src/widgets/videoDetail/stats/ui/VideoStatsSection.tsx
+++ b/src/widgets/videoDetail/stats/ui/VideoStatsSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { VideoStatsCard } from './VideoStatsCard'
-import { useVideoStats, mockVideoStats } from '@/features/videoDetail/stats'
+import { useVideoStats } from '@/features/videoDetail/stats'
 import { formatDate } from '@/shared/lib/format'
 import type { VideoStatsDto } from '@/entities/video'
 
@@ -124,10 +124,10 @@ interface VideoStatsSectionProps {
 }
 
 export function VideoStatsSection({ videoId }: VideoStatsSectionProps) {
-  const { data: apiData, isLoading } = useVideoStats(videoId)
-  const stats = apiData ?? mockVideoStats
+  const { data: stats, isLoading } = useVideoStats(videoId)
 
   if (isLoading) return null
+  if (!stats) return null
 
   const groups = buildGroups(stats)
 


### PR DESCRIPTION
컴포넌트에서 `apiData ?? mockXxx` 폴백 패턴을 모두 제거하고,
로딩/에러/빈 데이터 가드로 대체. mock 데이터가 실제 화면에 노출되지 않도록 함.

대상: KpiSection, ChannelProfileSection, ChannelSummarySection, VideoDetailPage, VideoStatsSection, InfluencerBaseInfo, ImpactMetricsSection, EngagementAnalyticsSection, RetentionSection

## 📌 작업 개요

> Button 컴포넌트 개발

## 🗂 작업 유형

> 해당하는 항목에 `x`를 채워 주세요.

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일 / UI 수정 (style)
- [ ] 성능 개선 (perf)
- [ ] 테스트 (test)
- [ ] 기타 (chore, docs 등)

## ✏️ 작업 내용

## ✅ 셀프 체크리스트

> 머지 전 직접 확인해 주세요.

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 콘솔 로그, 주석, 디버그 코드 제거
- [x] 타입 에러 없음

## 💬 리뷰어에게

>
