### PR TITLE
feat: 브랜드 협업 페이지 초기 진입 시 기본 영상 피드 노출

### DIFF
--- a/src/pages/competitor/ui/CompetitorPage.tsx
+++ b/src/pages/competitor/ui/CompetitorPage.tsx
@@ -29,9 +29,10 @@ export function CompetitorPage() {
     DEFAULT_COMPETITOR_FILTER
   )
 
-  /* 검색하기로 확정된 필터 — 이 값이 있어야 API 호출됨 */
-  const [appliedFilter, setAppliedFilter] =
-    useState<CompetitorFilterState | null>(null)
+  /* 검색하기로 확정된 필터 — 초기 진입 시 기본 필터로 기본 영상 피드를 노출 */
+  const [appliedFilter, setAppliedFilter] = useState<CompetitorFilterState>(
+    DEFAULT_COMPETITOR_FILTER
+  )
 
   /* 선택된 영상 ID 집합 (최대 10개) */
   const [selectedVideoIds, setSelectedVideoIds] = useState<Set<string>>(
@@ -57,10 +58,10 @@ export function CompetitorPage() {
     setDraftFilter((prev) => ({ ...prev, [key]: value }))
   }
 
-  /* 초기화: 편집 필터 + 적용 필터 + 선택/분석 영상 모두 초기 상태로 */
+  /* 초기화: 편집 필터 + 적용 필터(기본 피드) + 선택/분석 영상 모두 초기 상태로 */
   function handleReset() {
     setDraftFilter(DEFAULT_COMPETITOR_FILTER)
-    setAppliedFilter(null)
+    setAppliedFilter(DEFAULT_COMPETITOR_FILTER)
     setSelectedVideoIds(new Set())
     setAnalyzedVideoIds([])
   }
@@ -75,7 +76,6 @@ export function CompetitorPage() {
 
   /* 정렬 변경: 검색 결과에 즉시 반영 */
   function handleSortChange(next: SortCriteria) {
-    if (!appliedFilter) return
     setAppliedFilter({ ...appliedFilter, sortCriteria: next })
   }
 
@@ -128,27 +128,23 @@ export function CompetitorPage() {
           />
         )}
 
-        {appliedFilter && (
-          <>
-            <CompetitorSelectionBar
-              count={selectedVideoIds.size}
-              max={MAX_SELECTED}
-              onReset={handleClearSelection}
-              onAnalyze={handleAnalyze}
-            />
+        <CompetitorSelectionBar
+          count={selectedVideoIds.size}
+          max={MAX_SELECTED}
+          onReset={handleClearSelection}
+          onAnalyze={handleAnalyze}
+        />
 
-            <CompetitorResultSection
-              videos={videos}
-              selectedVideoIds={selectedVideoIds}
-              onToggleSelect={handleToggleSelect}
-              sortCriteria={appliedFilter.sortCriteria}
-              onSortChange={handleSortChange}
-              hasNextPage={hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
-              onLoadMore={() => fetchNextPage()}
-            />
-          </>
-        )}
+        <CompetitorResultSection
+          videos={videos}
+          selectedVideoIds={selectedVideoIds}
+          onToggleSelect={handleToggleSelect}
+          sortCriteria={appliedFilter.sortCriteria}
+          onSortChange={handleSortChange}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onLoadMore={() => fetchNextPage()}
+        />
       </div>
 
       <ScrollToTopButton />


### PR DESCRIPTION
appliedFilter 초기값을 기본 필터로 설정하여 페이지 마운트 시
includeKeywords 없이 brand-collaborations API를 호출, 전일 조회수 기준 상위 PPL 영상을 기본 노출. 키워드 입력 후 검색 흐름은 기존과 동일.

## 📌 작업 개요

> Button 컴포넌트 개발

## 🗂 작업 유형

> 해당하는 항목에 `x`를 채워 주세요.

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 스타일 / UI 수정 (style)
- [ ] 성능 개선 (perf)
- [ ] 테스트 (test)
- [ ] 기타 (chore, docs 등)

## ✏️ 작업 내용

## ✅ 셀프 체크리스트

> 머지 전 직접 확인해 주세요.

- [x] 로컬에서 정상 동작 확인
- [x] 불필요한 콘솔 로그, 주석, 디버그 코드 제거
- [x] 타입 에러 없음

## 💬 리뷰어에게

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 경쟁사 페이지에서 초기 진입 시 기본 필터가 자동으로 적용되어 검색 결과이 바로 표시됩니다.
  * 페이지 컴포넌트들이 더 일관되게 표시되도록 개선했습니다.
  * 정렬 변경 및 필터 초기화 기능의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->